### PR TITLE
Adding a ref to the input element.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ let AutoExpandingTextInput = React.createClass({
     return (
       <TextInput
         {...this.props}
+        ref="input"
         multiline={true}
         onChange={this._onChange}
         style={[styles.default, this.props.style, {height: tmpHeight}]}


### PR DESCRIPTION
Hi, there! Was just wondering if you could add a ref to the TextInput. Possibly useful for a bunch of things, but specifically to follow the setNativeProps pattern that Facebook recommends in order to clear text inputs. (via https://facebook.github.io/react-native/docs/direct-manipulation.html#setnativeprops-to-clear-textinput-value)
