### PR TITLE
Added support for RN 0.48+

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "peerDependencies": {
     "react": "^15.3.0",
-    "react-native": "^0.27.2"
+    "react-native": "^0.27.2",
+    "prop-types": "^15.6.0"
   },
   "jest": {
     "rootDir": "./",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alcat2008/react-native-auto-expanding-textinput.git"
+    "url": "git+https://github.com/praisegeek/react-native-auto-expanding-textinput.git"
   },
   "keywords": [
     "textinput",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import React, {
   Component,
-  PropTypes,
   PureComponent
 } from 'react';
+import PropTypes from 'prop-types';
+
 import {
   View,
   StyleSheet,
@@ -18,6 +19,8 @@ export default class AutoExpandingTextInput extends PureComponent {
       height: this.props.minHeight,
       maxHeight: this.props.maxHeight || this.props.minHeight * 3
     };
+    
+    this._onContentSizeChange = this._onContentSizeChange.bind(this)
   }
 
   static propTypes = {
@@ -36,7 +39,7 @@ export default class AutoExpandingTextInput extends PureComponent {
     }
   }
 
-  _onChange = (event) => {
+  _onContentSizeChange = (event) => {
     let curHeight = event.nativeEvent.contentSize.height;
     if (curHeight < this.props.minHeight || curHeight > this.state.maxHeight) return;
 
@@ -57,7 +60,7 @@ export default class AutoExpandingTextInput extends PureComponent {
       <TextInput
         {...this.props}
         multiline={true}
-        onChange={this._onChange}
+        onContentSizeChange={this._onContentSizeChange}
         style={[styles.default, this.props.style, {height: tmpHeight}]}
       />
     );

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,18 @@ export default class AutoExpandingTextInput extends PureComponent {
     }
   }
 
+  componentDidMount() {
+    this.props.onRef(this);
+  }
+
+  componentWillUnmount() {
+    this.props.onRef(undefined);
+  }
+
+  clear() {
+    this.Input.clear();
+  }
+
   _onContentSizeChange = (event) => {
     let curHeight = event.nativeEvent.contentSize.height;
     if (curHeight < this.props.minHeight || curHeight > this.state.maxHeight) return;
@@ -58,6 +70,7 @@ export default class AutoExpandingTextInput extends PureComponent {
     let tmpHeight = Math.min(this.state.maxHeight, this.state.height);
     return (
       <TextInput
+        ref={o => this.Input = o }
         {...this.props}
         multiline={true}
         onContentSizeChange={this._onContentSizeChange}


### PR DESCRIPTION
Fix all causing crashes for newer versions of react native. 

- Updated to use the new prop-types package

- Since RN 0.43+, contentSize is no longer chained to the nativeEvent emitted by onChange event handler, it has instead been named as onContentSizeChange which emits the required props

- Added prop-types as peer dependency